### PR TITLE
Implement diff parsing and patching basics

### DIFF
--- a/UniversalCodePatcher.Tests/DiffParserTests.cs
+++ b/UniversalCodePatcher.Tests/DiffParserTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UniversalCodePatcher.DiffEngine;
+using System.IO;
+using System.Linq;
+
+namespace UniversalCodePatcher.Tests
+{
+    [TestClass]
+    public class DiffParserTests
+    {
+        [TestMethod]
+        public void Parse_SimpleAddHunk_ReturnsSingleDiffFile()
+        {
+            var diffText = "--- a/FileA.cs\n+++ b/FileA.cs\n@@ -0,0 +1,3 @@\n+using System;\n+public class A { }\n";
+            File.WriteAllText("test.diff", diffText);
+            var parser = new DiffParser();
+            var result = parser.Parse("test.diff");
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual("FileA.cs", result[0].NewFilePath);
+            Assert.IsTrue(result[0].Hunks.Count == 1);
+            File.Delete("test.diff");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(DiffParseException))]
+        public void Parse_MalformedDiff_Throws()
+        {
+            File.WriteAllText("bad.diff", "This is not a diff");
+            var parser = new DiffParser();
+            parser.Parse("bad.diff");
+        }
+    }
+}

--- a/UniversalCodePatcher.Tests/PatchApplierTests.cs
+++ b/UniversalCodePatcher.Tests/PatchApplierTests.cs
@@ -1,0 +1,39 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UniversalCodePatcher.DiffEngine;
+using System.IO;
+using System.Linq;
+
+namespace UniversalCodePatcher.Tests
+{
+    [TestClass]
+    public class PatchApplierTests
+    {
+        [TestMethod]
+        public void Apply_SuccessfulHunk_ModifiesFile()
+        {
+            Directory.CreateDirectory("root");
+            File.WriteAllText("root/Hello.cs", "namespace Demo {}\n");
+            var diff = "--- a/Hello.cs\n+++ b/Hello.cs\n@@ -1,1 +1,2 @@\n namespace Demo {}\n+// Added comment\n";
+            File.WriteAllText("patch.diff", diff);
+            var applier = new PatchApplier(new SimpleLogger());
+            var result = applier.ApplyDiff("patch.diff", "root", "backup", false);
+            Assert.IsTrue(result.OverallSuccess);
+            var lines = File.ReadAllLines("root/Hello.cs");
+            Assert.IsTrue(lines.Any(l => l.Contains("Added comment")));
+        }
+
+        [TestMethod]
+        public void Apply_ContextMismatch_RollsBack()
+        {
+            Directory.CreateDirectory("root2");
+            File.WriteAllText("root2/Program.cs", "Console.WriteLine(\"Old\");\n");
+            var diff = "--- a/Program.cs\n+++ b/Program.cs\n@@ -1,1 +1,1 @@\n-Console.WriteLine(\"Different\");\n+Console.WriteLine(\"New\");\n";
+            File.WriteAllText("patch2.diff", diff);
+            var applier = new PatchApplier(new SimpleLogger());
+            var result = applier.ApplyDiff("patch2.diff", "root2", "backup2", false);
+            Assert.IsFalse(result.OverallSuccess);
+            var content = File.ReadAllText("root2/Program.cs");
+            Assert.IsTrue(content.Contains("Old"));
+        }
+    }
+}

--- a/UniversalCodePatcher.Tests/UniversalCodePatcher.Tests.csproj
+++ b/UniversalCodePatcher.Tests/UniversalCodePatcher.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\UniversalCodePatcher\UniversalCodePatcher.csproj" />
+  </ItemGroup>
+</Project>

--- a/UniversalCodePatcher/DiffEngine/DiffParser.cs
+++ b/UniversalCodePatcher/DiffEngine/DiffParser.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace UniversalCodePatcher.DiffEngine
+{
+    public class DiffParseException : Exception
+    {
+        public DiffParseException(string message) : base(message) { }
+    }
+
+    public enum ChangeType
+    {
+        Context,
+        Add,
+        Remove
+    }
+
+    public class DiffLine
+    {
+        public ChangeType Type { get; set; }
+        public string Text { get; set; } = string.Empty;
+        public int? LineNumber { get; set; }
+    }
+
+    public class Hunk
+    {
+        public int OriginalStartLine { get; set; }
+        public int OriginalLineCount { get; set; }
+        public int NewStartLine { get; set; }
+        public int NewLineCount { get; set; }
+        public IList<DiffLine> Lines { get; set; } = new List<DiffLine>();
+    }
+
+    public class DiffFile
+    {
+        public string OriginalFilePath { get; set; } = string.Empty;
+        public string NewFilePath { get; set; } = string.Empty;
+        public bool IsNewFile { get; set; }
+        public bool IsDeletedFile { get; set; }
+        public bool IsBinary { get; set; }
+        public IList<Hunk> Hunks { get; set; } = new List<Hunk>();
+    }
+
+    public class DiffParser
+    {
+        public IList<DiffFile> Parse(string diffFilePath)
+        {
+            if (!File.Exists(diffFilePath))
+                throw new FileNotFoundException(diffFilePath);
+
+            var lines = File.ReadAllLines(diffFilePath);
+            var result = new List<DiffFile>();
+            DiffFile? currentFile = null;
+            Hunk? currentHunk = null;
+            int lineIndex = 0;
+            while (lineIndex < lines.Length)
+            {
+                string line = lines[lineIndex];
+                if (line.StartsWith("diff --git"))
+                {
+                    currentFile = new DiffFile();
+                    result.Add(currentFile);
+                    var parts = line.Split(' ');
+                    if (parts.Length >= 4)
+                    {
+                        currentFile.OriginalFilePath = parts[2].Substring(2);
+                        currentFile.NewFilePath = parts[3].Substring(2);
+                    }
+                    lineIndex++;
+                    continue;
+                }
+                if (line.StartsWith("--- "))
+                {
+                    if (currentFile == null)
+                    {
+                        currentFile = new DiffFile();
+                        result.Add(currentFile);
+                    }
+                    currentFile.OriginalFilePath = line.Substring(4).Trim();
+                    if (currentFile.OriginalFilePath == "/dev/null")
+                    {
+                        currentFile.IsNewFile = true;
+                        currentFile.OriginalFilePath = currentFile.NewFilePath;
+                    }
+                    lineIndex++;
+                    if (lineIndex < lines.Length && lines[lineIndex].StartsWith("+++ "))
+                    {
+                        var newLine = lines[lineIndex];
+                        currentFile.NewFilePath = newLine.Substring(4).Trim();
+                        if (currentFile.NewFilePath == "/dev/null")
+                        {
+                            currentFile.IsDeletedFile = true;
+                            currentFile.NewFilePath = currentFile.OriginalFilePath;
+                        }
+                        lineIndex++;
+                    }
+                    continue;
+                }
+                if (line.StartsWith("Binary files") || line.StartsWith("GIT binary patch"))
+                {
+                    if (currentFile != null)
+                    {
+                        currentFile.IsBinary = true;
+                    }
+                    lineIndex++;
+                    continue;
+                }
+                if (line.StartsWith("@@"))
+                {
+                    if (currentFile == null)
+                        throw new DiffParseException("Hunk without file header");
+
+                    var header = line;
+                    var numbers = header.Split(' ');
+                    if (numbers.Length < 3)
+                        throw new DiffParseException($"Malformed hunk header: {header}");
+                    var orig = numbers[1];
+                    var mod = numbers[2];
+                    var origParts = orig.Substring(1).Split(',');
+                    var modParts = mod.Substring(1).Split(',');
+                    currentHunk = new Hunk
+                    {
+                        OriginalStartLine = int.Parse(origParts[0]),
+                        OriginalLineCount = origParts.Length > 1 ? int.Parse(origParts[1]) : 1,
+                        NewStartLine = int.Parse(modParts[0]),
+                        NewLineCount = modParts.Length > 1 ? int.Parse(modParts[1]) : 1
+                    };
+                    currentFile.Hunks.Add(currentHunk);
+                    lineIndex++;
+                    while (lineIndex < lines.Length)
+                    {
+                        var l = lines[lineIndex];
+                        if (l.StartsWith("@@") || l.StartsWith("diff --git") || l.StartsWith("--- "))
+                            break;
+                        if (currentHunk == null)
+                            throw new DiffParseException("Line outside hunk");
+                        if (l.StartsWith("+"))
+                        {
+                            currentHunk.Lines.Add(new DiffLine { Type = ChangeType.Add, Text = l.Substring(1) });
+                        }
+                        else if (l.StartsWith("-"))
+                        {
+                            currentHunk.Lines.Add(new DiffLine { Type = ChangeType.Remove, Text = l.Substring(1) });
+                        }
+                        else if (l.StartsWith(" "))
+                        {
+                            currentHunk.Lines.Add(new DiffLine { Type = ChangeType.Context, Text = l.Substring(1) });
+                        }
+                        lineIndex++;
+                    }
+                    continue;
+                }
+                lineIndex++;
+            }
+            return result;
+        }
+    }
+}

--- a/UniversalCodePatcher/DiffEngine/PatchApplier.cs
+++ b/UniversalCodePatcher/DiffEngine/PatchApplier.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace UniversalCodePatcher.DiffEngine
+{
+    public class PatchFailure
+    {
+        public string FilePath { get; set; } = string.Empty;
+        public int HunkIndex { get; set; }
+        public string ErrorMessage { get; set; } = string.Empty;
+        public IList<string> ExpectedContext { get; set; } = new List<string>();
+        public IList<string> ActualContext { get; set; } = new List<string>();
+    }
+
+    public class PatchResult
+    {
+        public bool OverallSuccess => Failures.Count == 0;
+        public IList<string> PatchedFiles { get; } = new List<string>();
+        public IList<PatchFailure> Failures { get; } = new List<PatchFailure>();
+        public IList<string> SkippedFiles { get; } = new List<string>();
+        public void Merge(PatchResult other)
+        {
+            foreach (var f in other.PatchedFiles) PatchedFiles.Add(f);
+            foreach (var f in other.Failures) Failures.Add(f);
+            foreach (var s in other.SkippedFiles) SkippedFiles.Add(s);
+        }
+    }
+
+    public class PatchApplier
+    {
+        private readonly ILogger _logger;
+        public PatchApplier(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public PatchResult Apply(DiffFile diff, string rootFolder, string backupFolder, bool dryRun)
+        {
+            var result = new PatchResult();
+            var targetPath = Path.Combine(rootFolder, diff.OriginalFilePath);
+            if (diff.IsBinary)
+            {
+                result.SkippedFiles.Add(diff.OriginalFilePath);
+                _logger.LogWarning($"Binary file {diff.OriginalFilePath} skipped");
+                return result;
+            }
+            if (diff.IsDeletedFile)
+            {
+                if (File.Exists(targetPath))
+                {
+                    BackupFile(targetPath, backupFolder);
+                    if (!dryRun)
+                        File.Delete(targetPath);
+                    result.PatchedFiles.Add(diff.OriginalFilePath);
+                }
+                else
+                {
+                    result.SkippedFiles.Add(diff.OriginalFilePath);
+                }
+                return result;
+            }
+            if (!File.Exists(targetPath))
+            {
+                if (diff.IsNewFile)
+                {
+                    if (!dryRun)
+                    {
+                        Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                        File.WriteAllLines(targetPath, diff.Hunks.SelectMany(h => h.Lines.Where(l => l.Type == ChangeType.Add).Select(l => l.Text)));
+                    }
+                    result.PatchedFiles.Add(diff.NewFilePath);
+                    return result;
+                }
+                result.SkippedFiles.Add(diff.OriginalFilePath);
+                return result;
+            }
+
+            var originalLines = File.ReadAllLines(targetPath).ToList();
+            var newline = originalLines.Any(l => l.EndsWith("\r")) ? "\r\n" : "\n";
+            BackupFile(targetPath, backupFolder);
+            for (int i = 0; i < diff.Hunks.Count; i++)
+            {
+                var hunk = diff.Hunks[i];
+                var position = hunk.OriginalStartLine - 1;
+                if (position < 0 || position > originalLines.Count)
+                {
+                    result.Failures.Add(new PatchFailure
+                    {
+                        FilePath = diff.OriginalFilePath,
+                        HunkIndex = i,
+                        ErrorMessage = "Context mismatch",
+                    });
+                    return result;
+                }
+                foreach (var line in hunk.Lines)
+                {
+                    if (line.Type == ChangeType.Context)
+                    {
+                        if (position >= originalLines.Count || originalLines[position] != line.Text)
+                        {
+                            result.Failures.Add(new PatchFailure { FilePath = diff.OriginalFilePath, HunkIndex = i, ErrorMessage = "Context mismatch" });
+                            return result;
+                        }
+                        position++;
+                    }
+                    else if (line.Type == ChangeType.Remove)
+                    {
+                        if (position >= originalLines.Count || originalLines[position] != line.Text)
+                        {
+                            result.Failures.Add(new PatchFailure { FilePath = diff.OriginalFilePath, HunkIndex = i, ErrorMessage = "Context mismatch" });
+                            return result;
+                        }
+                        originalLines.RemoveAt(position);
+                    }
+                    else if (line.Type == ChangeType.Add)
+                    {
+                        originalLines.Insert(position, line.Text);
+                        position++;
+                    }
+                }
+            }
+            if (!dryRun)
+            {
+                File.WriteAllLines(targetPath, originalLines.Select(l => l.Replace("\n", string.Empty)), System.Text.Encoding.UTF8);
+            }
+            result.PatchedFiles.Add(diff.OriginalFilePath);
+            return result;
+        }
+
+        private void BackupFile(string path, string backupFolder)
+        {
+            Directory.CreateDirectory(backupFolder);
+            var backupPath = Path.Combine(backupFolder, Path.GetFileName(path) + ".bak");
+            File.Copy(path, backupPath, true);
+        }
+
+        public PatchResult ApplyDiff(string diffFilePath, string rootFolder, string backupFolder, bool dryRun)
+        {
+            var parser = new DiffParser();
+            var diffFiles = parser.Parse(diffFilePath);
+            var aggregate = new PatchResult();
+            foreach (var df in diffFiles)
+            {
+                var r = Apply(df, rootFolder, backupFolder, dryRun);
+                aggregate.Merge(r);
+            }
+            return aggregate;
+        }
+    }
+}

--- a/UniversalCodePatcher/Helpers/FileScanner.cs
+++ b/UniversalCodePatcher/Helpers/FileScanner.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace UniversalCodePatcher.Helpers
+{
+    public static class FileScanner
+    {
+        public static IEnumerable<string> FindPatchableFiles(string rootFolder, IReadOnlyCollection<string> includeExtensions, IReadOnlyCollection<string> excludeFolderNames)
+        {
+            var comparer = System.StringComparer.OrdinalIgnoreCase;
+            foreach (var file in Directory.EnumerateFiles(rootFolder, "*.*", SearchOption.AllDirectories))
+            {
+                string relative = file.Substring(rootFolder.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                if (segments.Any(s => excludeFolderNames.Contains(s, comparer)))
+                    continue;
+                if (includeExtensions.Contains(Path.GetExtension(file), comparer))
+                    yield return file;
+            }
+        }
+    }
+}

--- a/UniversalCodePatcher/Logger.cs
+++ b/UniversalCodePatcher/Logger.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace UniversalCodePatcher
+{
+    public enum LogLevel { Info, Warning, Error }
+
+    public class LogEntry
+    {
+        public LogLevel Level { get; }
+        public string Message { get; }
+        public DateTime Timestamp { get; }
+        public LogEntry(LogLevel level, string message)
+        {
+            Level = level;
+            Message = message;
+            Timestamp = DateTime.Now;
+        }
+    }
+
+    public interface ILogger
+    {
+        void LogInfo(string message);
+        void LogWarning(string message);
+        void LogError(string message);
+        event Action<LogEntry> OnLogged;
+    }
+
+    public class SimpleLogger : ILogger
+    {
+        public event Action<LogEntry>? OnLogged;
+        public void LogInfo(string message) => Log(LogLevel.Info, message);
+        public void LogWarning(string message) => Log(LogLevel.Warning, message);
+        public void LogError(string message) => Log(LogLevel.Error, message);
+
+        private void Log(LogLevel level, string message)
+        {
+            var entry = new LogEntry(level, message);
+            OnLogged?.Invoke(entry);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DiffParser and PatchApplier with simple unified diff support
- include FileScanner helper and logging abstraction
- create unit tests for parser and patch applier

## Testing
- `dotnet build UniversalCodePatcher/UniversalCodePatcher.csproj -c Release` *(fails: command not found)*
- `dotnet test UniversalCodePatcher.Tests/UniversalCodePatcher.Tests.csproj -c Release --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684082d40558832c9bfc46e9f0844415