### PR TITLE
Skip GUI project on non-Windows

### DIFF
--- a/UniversalCodePatcher.GUI/UniversalCodePatcher.GUI.csproj
+++ b/UniversalCodePatcher.GUI/UniversalCodePatcher.GUI.csproj
@@ -1,11 +1,28 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project>
   <PropertyGroup>
+    <BuildProject Condition="'$(OS)' == 'Windows_NT'">true</BuildProject>
+    <BuildProject Condition="'$(OS)' != 'Windows_NT'">false</BuildProject>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="'$(BuildProject)' == 'true'" />
+
+  <PropertyGroup Condition="'$(BuildProject)' == 'true'">
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(BuildProject)' != 'true'">
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\UniversalCodePatcher\UniversalCodePatcher.csproj" />
   </ItemGroup>
+
+  <Target Name="SkipOnNonWindows" Condition="'$(BuildProject)' != 'true'">
+    <Message Importance="high" Text="Skipping GUI project build because not on Windows." />
+  </Target>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Condition="'$(BuildProject)' == 'true'" />
 </Project>


### PR DESCRIPTION
## Summary
- conditionally import the Windows desktop SDK in the GUI project
- skip building the GUI project on non-Windows and log a message

## Testing
- `dotnet build UniversalCodePatcher.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68413d6403f4832c9e95eb458aec8254