### PR TITLE
Fix logger type for GUI build

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/PatchForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/PatchForm.cs
@@ -19,7 +19,7 @@ namespace UniversalCodePatcher.Forms
         private Button browseBackupButton = new() { Text = "Browse Backup" };
         private RichTextBox logBox = new() { ReadOnly = true, Dock = DockStyle.Bottom, Height = 150 };
         private ProgressBar progress = new() { Dock = DockStyle.Bottom };
-        private ILogger logger = new ListLogger();
+        private DiffEngine.ILogger logger = new DiffEngine.ListLogger();
 
         public PatchForm()
         {


### PR DESCRIPTION
## Summary
- ensure PatchForm uses the DiffEngine logger interface

## Testing
- `dotnet test UniversalCodePatcher.Tests/UniversalCodePatcher.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6841404f1594832c8f41ace3418c9e5f