### PR TITLE
Fix WinForms splitter initialization on load

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
@@ -87,7 +87,6 @@ namespace UniversalCodePatcher.Forms
             // splitMain
             // 
             this.splitMain.Dock = DockStyle.Fill;
-            this.splitMain.SplitterDistance = 250;
             this.splitMain.Panel1MinSize = 150;
             this.splitMain.Panel2MinSize = 300;
             // 
@@ -147,7 +146,6 @@ namespace UniversalCodePatcher.Forms
             // splitPreview
             // 
             this.splitPreview.Dock = DockStyle.Fill;
-            this.splitPreview.SplitterDistance = 300;
             this.splitPreview.Panel1.Controls.Add(this.rtbOriginal);
             this.splitPreview.Panel2.Controls.Add(this.rtbPatched);
             // 

--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -11,6 +11,17 @@ namespace UniversalCodePatcher.Forms
         public MainForm()
         {
             InitializeComponent();
+            // Ensure splitter positions are set after layout is calculated
+            Load += MainForm_Load;
+        }
+
+        private void MainForm_Load(object? sender, EventArgs e)
+        {
+            // Center splitters once the form has been created
+            if (splitMain.Width > 0)
+                splitMain.SplitterDistance = splitMain.Width / 2;
+            if (splitPreview.Width > 0)
+                splitPreview.SplitterDistance = splitPreview.Width / 2;
         }
 
         private void btnLoadProject_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- avoid setting splitter distance in designer
- center splitters when the form loads

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684146071518832cba506f0e188e030b