### PR TITLE
Replace TableLayoutPanel in MainForm

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
@@ -11,6 +11,8 @@ namespace UniversalCodePatcher.Forms
         private ResizablePanel sidePanel;
         private Panel mainContentPanel;
         private TreeView treeProjectFiles;
+        private TabControl tabMain;
+        private TabPage tabRules;
         private TextBox txtLogOutput;
         private Button btnLoadProject;
         private Button btnScan;
@@ -24,6 +26,8 @@ namespace UniversalCodePatcher.Forms
             this.btnScan = new Button();
             this.btnApplyRules = new Button();
             this.treeProjectFiles = new TreeView();
+            this.tabMain = new TabControl();
+            this.tabRules = new TabPage();
             this.txtLogOutput = new TextBox();
 
             // topPanel
@@ -51,6 +55,13 @@ namespace UniversalCodePatcher.Forms
             this.btnApplyRules.Left = 195;
             this.btnApplyRules.Click += new System.EventHandler(this.btnApplyRules_Click);
 
+            // tabMain
+            this.tabMain.Dock = DockStyle.Fill;
+            this.tabMain.Controls.Add(this.tabRules);
+
+            // tabRules
+            this.tabRules.Text = "Rules";
+
             // txtLogOutput
             this.txtLogOutput.Dock = DockStyle.Bottom;
             this.txtLogOutput.Multiline = true;
@@ -58,24 +69,25 @@ namespace UniversalCodePatcher.Forms
 
             // layout
             this.layoutManager = new DockLayoutManager();
-            this.sidePanel = new ResizablePanel() { WidthPercentage = 0.3 };
-            this.mainContentPanel = new Panel() { Dock = DockStyle.Fill };
+            this.sidePanel = new ResizablePanel() { Name = "sidePanel", WidthPercentage = 0.3 };
+            this.mainContentPanel = new Panel() { Name = "mainContentPanel" };
 
             var dockableControls = new List<DockableControl>
             {
-                new() { Control = sidePanel, Dock = DockStyle.Left, WidthPercentage = 0.3 },
+                new() { Control = sidePanel, Dock = DockStyle.Left, WidthPercentage = 0.3, MinimumWidth = 250 },
                 new() { Control = mainContentPanel, Dock = DockStyle.Fill }
             };
 
-            this.layoutManager.ArrangeControls(this, dockableControls);
-
             // move existing controls
             this.sidePanel.Controls.Add(this.treeProjectFiles);
+            this.mainContentPanel.Controls.Add(this.tabMain);
 
             // form
             this.ClientSize = new Size(800, 600);
             this.Controls.Add(this.txtLogOutput);
             this.Controls.Add(this.topPanel);
+            this.layoutManager.ArrangeControls(this, dockableControls);
+            this.Resize += new System.EventHandler(this.MainForm_Resize);
             this.Text = "Universal Code Patcher";
         }
     }

--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -24,8 +24,9 @@ namespace UniversalCodePatcher.Forms
             workflowEngine = new WorkflowEngine();
             ruleBuilder = new RuleBuilderPanel();
 
-            mainContentPanel.Controls.Clear();
-            mainContentPanel.Controls.Add(ruleBuilder);
+            tabRules.Controls.Clear();
+            ruleBuilder.Dock = DockStyle.Fill;
+            tabRules.Controls.Add(ruleBuilder);
         }
 
         private void btnLoadProject_Click(object sender, EventArgs e)
@@ -90,6 +91,11 @@ namespace UniversalCodePatcher.Forms
         private void Log(string message)
         {
             txtLogOutput.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}");
+        }
+
+        private void MainForm_Resize(object? sender, EventArgs e)
+        {
+            layoutManager.UpdateLayout(this);
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove old TableLayoutPanel usage
- add DockLayoutManager layout with ResizablePanel
- introduce TabControl for main content
- update MainForm workflow initialization
- refresh layout on form resize

## Testing
- `dotnet build UniversalCodePatcher.sln` *(fails: command not found)*
- `dotnet test UniversalCodePatcher.Tests/UniversalCodePatcher.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ab271960832c94902ff820776389