### PR TITLE
Fix resize handler signature

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -93,7 +93,7 @@ namespace UniversalCodePatcher.Forms
             txtLogOutput.AppendText($"[{DateTime.Now:HH:mm:ss}] {message}{Environment.NewLine}");
         }
 
-        private void MainForm_Resize(object? sender, EventArgs e)
+        private void MainForm_Resize(object sender, EventArgs e)
         {
             layoutManager.UpdateLayout(this);
         }


### PR DESCRIPTION
## Summary
- fix nullable parameter on MainForm resize handler

## Testing
- `dotnet test` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_6841af7fa630832cad97b62df9720189