### PR TITLE
Fix MainForm menu and apply logic

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
@@ -12,9 +12,22 @@ namespace UniversalCodePatcher.Forms
         private void InitializeComponent()
         {
             menuStrip = new MenuStrip();
-            menuStrip.Items.Add("File");
-            menuStrip.Items.Add("Patch");
-            menuStrip.Items.Add("Help");
+
+            var fileMenu = new ToolStripMenuItem("File");
+            fileMenu.DropDownItems.Add("Open Diff...", null, OnBrowseDiff);
+            fileMenu.DropDownItems.Add("Exit", null, (s, e) => Close());
+
+            var patchMenu = new ToolStripMenuItem("Patch");
+            patchMenu.DropDownItems.Add("Apply All", null, OnApply);
+            patchMenu.DropDownItems.Add("Clear", null, OnClear);
+
+            var helpMenu = new ToolStripMenuItem("Help");
+            helpMenu.DropDownItems.Add("About", null, (s, e) =>
+                MessageBox.Show("Universal Code Patcher v1.0"));
+
+            menuStrip.Items.Add(fileMenu);
+            menuStrip.Items.Add(patchMenu);
+            menuStrip.Items.Add(helpMenu);
 
             diffBox.Multiline = true;
             diffBox.Font = new Font("Consolas", 10);

--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Drawing;
 using System.Windows.Forms;
 using UniversalCodePatcher.DiffEngine;
@@ -18,7 +17,6 @@ namespace UniversalCodePatcher.Forms
         private readonly ModernButton applyButton = new() { Text = "Apply" };
         private readonly ModernButton clearButton = new() { Text = "Clear" };
         private readonly ModernButton browseFolderButton = new() { Text = "Browse Folder" };
-        private readonly PatchApplier applier = new(new UniversalCodePatcher.SimpleLogger());
 
         public MainForm()
         {
@@ -52,13 +50,10 @@ namespace UniversalCodePatcher.Forms
                 MessageBox.Show("Select project folder");
                 return;
             }
-            progress.Style = ProgressBarStyle.Marquee;
-            var result = applier.ApplyDiffText(diffBox.Text, folderBox.Text, Path.Combine(folderBox.Text, "patch_backups"), false);
-            progress.Style = ProgressBarStyle.Continuous;
-            progress.Value = 100;
-            logBox.AppendText($"Patched: {string.Join(", ", result.PatchedFiles)}{Environment.NewLine}");
-            foreach (var f in result.Failures)
-                logBox.AppendText($"Failed: {f.FilePath} - {f.ErrorMessage}{Environment.NewLine}");
+            string backup = Path.Combine(folderBox.Text, "patch_backups");
+            var result = DiffApplier.ApplyDiff(diffBox.Text, folderBox.Text, backup, false);
+
+            logBox.AppendText($"Patched files: {result.PatchedFiles.Count}{Environment.NewLine}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement functional menu items with handlers
- remove use of `PatchApplier`/`SimpleLogger`
- update `OnApply` to call `DiffApplier`

## Testing
- `dotnet --version`
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b9b8eed8832cb1f2fb8ae4ad34a9