### PR TITLE
Fix designer parsing error

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
@@ -15,7 +15,7 @@ namespace UniversalCodePatcher.Forms
 
             var fileMenu = new ToolStripMenuItem("File");
             fileMenu.DropDownItems.Add("Open Diff...", null, OnBrowseDiff);
-            fileMenu.DropDownItems.Add("Exit", null, (s, e) => Close());
+            fileMenu.DropDownItems.Add("Exit", null, OnExit);
 
             var patchMenu = new ToolStripMenuItem("Patch");
             patchMenu.DropDownItems.Add("Apply All", null, OnApply);

--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -55,5 +55,10 @@ namespace UniversalCodePatcher.Forms
 
             logBox.AppendText($"Patched files: {result.PatchedFiles.Count}{Environment.NewLine}");
         }
+
+        private void OnExit(object? sender, EventArgs e)
+        {
+            Close();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle File menu Exit event in code-behind instead of inline lambda
- add `OnExit` handler for the main form

## Testing
- `dotnet test UniversalCodePatcher.Tests/UniversalCodePatcher.Tests.csproj --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_6841bb32cfd0832cb17c98b87d09da2e