### PR TITLE
Fix patch application by writing diff to temp file

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -51,9 +51,31 @@ namespace UniversalCodePatcher.Forms
                 return;
             }
             string backup = Path.Combine(folderBox.Text, "patch_backups");
-            var result = DiffApplier.ApplyDiff(diffBox.Text, folderBox.Text, backup, false);
 
-            logBox.AppendText($"Patched files: {result.PatchedFiles.Count}{Environment.NewLine}");
+            string tempDiffFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(tempDiffFile, diffBox.Text);
+
+                var result = DiffApplier.ApplyDiff(tempDiffFile, folderBox.Text, backup, false);
+
+                logBox.AppendText($"Patched files: {result.PatchedFiles.Count}{Environment.NewLine}");
+            }
+            catch (IOException ex)
+            {
+                MessageBox.Show($"Failed to apply patch: {ex.Message}");
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(tempDiffFile))
+                        File.Delete(tempDiffFile);
+                }
+                catch
+                {
+                }
+            }
         }
 
         private void OnExit(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
- handle diff text properly in GUI OnApply
- write diff to a temporary file and call existing DiffApplier
- ensure cleanup and show error messages if applying fails

## Testing
- `~/.dotnet/dotnet test UniversalCodePatcher.Tests/UniversalCodePatcher.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6841bf9407f4832cb557e7dce84c7b3e