### PR TITLE
Fix duplicate control fields in MainForm

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
@@ -12,11 +12,6 @@ namespace UniversalCodePatcher.Forms
         private GroupBox targetCard = null!;
         private GroupBox actionCard = null!;
         private GroupBox resultsCard = null!;
-        private Label diffStatusLabel = null!;
-        private ModernButton previewButton = null!;
-        private ModernButton undoButton = null!;
-        private CheckBox backupCheckBox = null!;
-        private CheckBox dryRunCheckBox = null!;
 
         private void InitializeComponent()
         {


### PR DESCRIPTION
## Summary
- remove duplicate control fields from `MainForm.Designer`

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: ApplyDiff_IgnoresWhitespaceDifferences)*

------
https://chatgpt.com/codex/tasks/task_e_6841cc5f05f4832cbddab5db860db12f