### PR TITLE
Fix build and update tests

### DIFF
--- a/UniversalCodePatcher.Tests/DiffApplierTests.cs
+++ b/UniversalCodePatcher.Tests/DiffApplierTests.cs
@@ -112,7 +112,8 @@ namespace UniversalCodePatcher.Tests
             var backupDir = Path.Combine(root, "backup");
             using var fs = File.Open(file, FileMode.Open, FileAccess.Read, FileShare.Read);
             var result = DiffApplier.ApplyDiff(diffPath, root, backupDir, false);
-            Assert.IsTrue(result.RolledBackFiles.ContainsKey(file));
+            var rolledBack = (System.Collections.Generic.Dictionary<string, string>)result.Metadata["RolledBackFiles"];
+            Assert.IsTrue(rolledBack.ContainsKey(file));
             Assert.AreEqual("old", File.ReadAllText(file));
             fs.Dispose();
             Directory.Delete(root, true);


### PR DESCRIPTION
## Summary
- rewrite `DiffApplier` to restore valid logic
- adjust `DiffApplierTests` to use metadata for rolled-back files

## Testing
- `dotnet build UniversalCodePatcher`
- `dotnet build UniversalCodePatcher.Tests`
- `dotnet test UniversalCodePatcher.Tests`

------
https://chatgpt.com/codex/tasks/task_e_6841d78162a8832cab58e82937fb6096