### PR TITLE
Fix compile error in MainForm

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -145,9 +145,6 @@ namespace UniversalCodePatcher.Forms
  
                 if (!applyCts.IsCancellationRequested)
                 {
-                    logBox.AppendText($"Modified: {string.Join(", ", result.PatchedFiles)}{Environment.NewLine}");
- 
-
                     var dirs = Directory.GetDirectories(backupRoot);
                     if (dirs.Length > 0)
                         lastBackupDir = dirs.OrderByDescending(d => d).First();


### PR DESCRIPTION
## Summary
- remove reference to removed `PatchedFiles` property

## Testing
- `dotnet build UniversalCodePatcher.GUI/UniversalCodePatcher.GUI.csproj -p:EnableWindowsTargeting=true`
- `dotnet test UniversalCodePatcher.sln -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_6841d9453694832cb9244d90d59c1144