### PR TITLE
Fix missing namespace for PatchResult

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using UniversalCodePatcher.DiffEngine;
 using UniversalCodePatcher.Controls;
+using UniversalCodePatcher.Models;
 
 namespace UniversalCodePatcher.Forms
 {


### PR DESCRIPTION
## Summary
- add Models namespace to MainForm to ensure PatchResult.Metadata compiles

## Testing
- `dotnet build UniversalCodePatcher.sln -v minimal`
- `dotnet test UniversalCodePatcher.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6841de85eb80832c9556aa187292d2af