### PR TITLE
Fix GUI build and update list pattern

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -141,9 +141,8 @@ namespace UniversalCodePatcher.Forms
                 var result = await Task.Run(() =>
                     DiffApplier.ApplyDiff(tempDiffFile, folderBox.Text, backupRoot, dryRunCheckBox.Checked));
 
-                var modified = result.Metadata.TryGetValue("PatchedFiles", out var patchedObj) && patchedObj is List<string> list
-                    ? list
-                    : new List<string>();
+                result.Metadata.TryGetValue("PatchedFiles", out var patchedObj);
+                var modified = patchedObj as List<string> ?? new List<string>();
                 logBox.AppendText($"Modified: {string.Join(", ", modified)}{Environment.NewLine}");
  
                 if (!applyCts.IsCancellationRequested)

--- a/UniversalCodePatcher.GUI/UniversalCodePatcher.GUI.csproj
+++ b/UniversalCodePatcher.GUI/UniversalCodePatcher.GUI.csproj
@@ -3,6 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- enable Windows targeting so GUI project can build on Linux
- simplify patched files extraction to avoid unassigned variable warning

## Testing
- `dotnet build UniversalCodePatcher.sln -c Release`
- `dotnet test UniversalCodePatcher.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6841e4222acc832c8f12104381132e49