### PR TITLE
Fix metadata property access

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -141,9 +141,8 @@ namespace UniversalCodePatcher.Forms
                 var result = await Task.Run(() =>
                     DiffApplier.ApplyDiff(tempDiffFile, folderBox.Text, backupRoot, dryRunCheckBox.Checked));
 
-                var modified = result.Metadata.TryGetValue("PatchedFiles", out var patchedObj) && patchedObj is List<string> list
-                    ? list
-                    : new List<string>();
+                result.Metadata.TryGetValue("PatchedFiles", out var patchedObj);
+                var modified = patchedObj as List<string> ?? new List<string>();
                 logBox.AppendText($"Modified: {string.Join(", ", modified)}{Environment.NewLine}");
  
                 if (!applyCts.IsCancellationRequested)

--- a/UniversalCodePatcher.GUI/UniversalCodePatcher.GUI.csproj
+++ b/UniversalCodePatcher.GUI/UniversalCodePatcher.GUI.csproj
@@ -3,6 +3,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/UniversalCodePatcher.Tests/PatchResultTests.cs
+++ b/UniversalCodePatcher.Tests/PatchResultTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UniversalCodePatcher.Models;
+using System.Collections.Generic;
+
+namespace UniversalCodePatcher.Tests
+{
+    [TestClass]
+    public class PatchResultTests
+    {
+        [TestMethod]
+        public void Metadata_AllowsAddingValues()
+        {
+            var result = new PatchResult();
+            result.Metadata["foo"] = "bar";
+            Assert.AreEqual("bar", result.Metadata["foo"]);
+        }
+
+        [TestMethod]
+        public void Metadata_IsInitialized()
+        {
+            var result = new PatchResult();
+            Assert.IsNotNull(result.Metadata);
+            Assert.AreEqual(0, result.Metadata.Count);
+        }
+    }
+}

--- a/UniversalCodePatcher/Models/Results.cs
+++ b/UniversalCodePatcher/Models/Results.cs
@@ -14,7 +14,10 @@ namespace UniversalCodePatcher.Models
         public List<string> Warnings { get; set; } = new();
         public int ElementsModified { get; set; }
         public TimeSpan Duration { get; set; }
-        public Dictionary<string, object> Metadata { get; set; } = new();
+        /// <summary>
+        /// Additional data produced during patching
+        /// </summary>
+        public IDictionary<string, object> Metadata { get; } = new Dictionary<string, object>();
     }
     
     /// <summary>


### PR DESCRIPTION
## Summary
- expose metadata via `IDictionary` in `PatchResult`
- keep patched files extraction logic in MainForm
- add tests for `PatchResult.Metadata`

## Testing
- `dotnet build UniversalCodePatcher.sln -c Release`
- `dotnet test UniversalCodePatcher.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6841e4222acc832c8f12104381132e49