### PR TITLE
Fix Build.bat to run .NET 8 release

### DIFF
--- a/Build.bat
+++ b/Build.bat
@@ -4,7 +4,7 @@ dotnet build "UniversalCodePatcher.sln" --configuration Release
 if %errorlevel% == 0 (
     echo Build successful!
     echo Starting application...
-    start "UniversalCodePatcher\bin\Release\net6.0-windows\UniversalCodePatcher.exe"
+    start "UniversalCodePatcher\bin\Release\net8.0-windows\UniversalCodePatcher.exe"
 ) else (
     echo Build failed!
     pause


### PR DESCRIPTION
## Summary
- launch the built GUI from the `net8.0-windows` folder

## Testing
- `dotnet build UniversalCodePatcher.sln --configuration Debug`
- `dotnet test --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_684282be6874832c960b0cfa3745499e