### PR TITLE
Pass CancellationToken to ApplyDiff

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -138,8 +138,9 @@ namespace UniversalCodePatcher.Forms
             {
                 File.WriteAllText(tempDiffFile, diffBox.Text);
 
+                var token = applyCts.Token;
                 var result = await Task.Run(() =>
-                    DiffApplier.ApplyDiff(tempDiffFile, folderBox.Text, backupRoot, dryRunCheckBox.Checked));
+                    DiffApplier.ApplyDiff(tempDiffFile, folderBox.Text, backupRoot, dryRunCheckBox.Checked, token), token);
 
                 result.Metadata.TryGetValue("PatchedFiles", out var patchedObj);
                 var modified = patchedObj as List<string> ?? new List<string>();


### PR DESCRIPTION
## Summary
- pipe the active CancellationToken to `DiffApplier.ApplyDiff` in `MainForm` and `PatchForm`
- create a local `CancellationTokenSource` in `PatchForm` and update logic to use the token

## Testing
- `~/.dotnet/dotnet test UniversalCodePatcher.Tests/UniversalCodePatcher.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684282b39a68832c873da0c495436617