### PR TITLE
Improve main interface styling

### DIFF
--- a/UniversalCodePatcher.GUI/Controls/ModernButton.cs
+++ b/UniversalCodePatcher.GUI/Controls/ModernButton.cs
@@ -9,7 +9,8 @@ namespace UniversalCodePatcher.Controls
     /// </summary>
     public class ModernButton : Button
     {
-        public Color AccentColor { get; set; } = Color.FromArgb(66, 153, 225);
+        // Default accent color uses modern Microsoft blue
+        public Color AccentColor { get; set; } = Color.FromArgb(0, 120, 212);
 
         public bool ShowIcon { get; set; } = true;
 

--- a/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.Designer.cs
@@ -8,14 +8,18 @@ namespace UniversalCodePatcher.Forms
     {
         private MenuStrip menuStrip = null!;
         private Panel mainPanel = null!;
-        private GroupBox inputCard = null!;
-        private GroupBox targetCard = null!;
-        private GroupBox actionCard = null!;
-        private GroupBox resultsCard = null!;
+        private Panel inputCard = null!;
+        private Panel targetCard = null!;
+        private Panel actionCard = null!;
+        private Panel resultsCard = null!;
 
         private void InitializeComponent()
         {
-            menuStrip = new MenuStrip();
+            menuStrip = new MenuStrip
+            {
+                BackColor = Color.FromArgb(45, 45, 45),
+                ForeColor = Color.White
+            };
 
             var fileMenu = new ToolStripMenuItem("File");
             fileMenu.DropDownItems.Add("Open Diff...", null, OnBrowseDiff);
@@ -34,23 +38,37 @@ namespace UniversalCodePatcher.Forms
             menuStrip.Items.Add(helpMenu);
 
             diffStatusLabel.AutoSize = true;
+            diffStatusLabel.Font = new Font("Segoe UI", 9F, FontStyle.Regular);
+            diffStatusLabel.ForeColor = Color.FromArgb(179, 179, 179);
+
             previewButton.Text = "Preview";
             undoButton.Text = "Undo";
             undoButton.Enabled = false;
             backupCheckBox.Text = "Create backup";
             backupCheckBox.Checked = true;
+            backupCheckBox.ForeColor = Color.FromArgb(179, 179, 179);
+            backupCheckBox.Font = new Font("Segoe UI", 10F);
             dryRunCheckBox.Text = "Dry run";
+            dryRunCheckBox.ForeColor = Color.FromArgb(179, 179, 179);
+            dryRunCheckBox.Font = new Font("Segoe UI", 10F);
 
             diffBox.Multiline = true;
             diffBox.Font = new Font("Consolas", 10);
             diffBox.Dock = DockStyle.Fill;
+            diffBox.BackColor = Color.FromArgb(40, 40, 40);
+            diffBox.ForeColor = Color.White;
             diffBox.PlaceholderText = "Paste your diff here...";
             diffBox.TextChanged += diffBox_TextChanged;
 
             folderBox.Dock = DockStyle.Fill;
+            folderBox.BackColor = Color.FromArgb(40, 40, 40);
+            folderBox.ForeColor = Color.White;
+            folderBox.Font = new Font("Segoe UI", 10F);
             logBox.Multiline = true;
             logBox.Dock = DockStyle.Fill;
             logBox.Font = new Font("Consolas", 9);
+            logBox.BackColor = Color.FromArgb(40, 40, 40);
+            logBox.ForeColor = Color.White;
 
             browseDiffButton.Click += OnBrowseDiff;
             applyButton.Click += OnApply;
@@ -58,49 +76,122 @@ namespace UniversalCodePatcher.Forms
             browseFolderButton.Click += OnBrowseFolder;
             undoButton.Click += OnUndo;
 
-            mainPanel = new Panel { Dock = DockStyle.Fill, Padding = new Padding(6) };
+            mainPanel = new Panel
+            {
+                Dock = DockStyle.Fill,
+                Padding = new Padding(16),
+                BackColor = Color.FromArgb(30, 30, 30)
+            };
 
             // Input card
-            inputCard = new GroupBox { Text = "\uD83D\uDCC4 Input Diff", Dock = DockStyle.Top, Height = 180 };
+            inputCard = new Panel
+            {
+                Dock = DockStyle.Top,
+                Height = 180,
+                Padding = new Padding(16),
+                BackColor = Color.FromArgb(45, 45, 45),
+                Margin = new Padding(0, 0, 0, 16)
+            };
+            var inputHeader = new Label
+            {
+                Text = "\uD83D\uDCC4 DIFF INPUT",
+                Dock = DockStyle.Top,
+                Font = new Font("Segoe UI", 12F, FontStyle.Bold),
+                ForeColor = Color.White,
+                Padding = new Padding(0, 0, 0, 8)
+            };
             var inputLayout = new TableLayoutPanel { Dock = DockStyle.Fill, RowCount = 2 };
             inputLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
             inputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
             inputLayout.Controls.Add(diffBox, 0, 0);
             inputLayout.Controls.Add(diffStatusLabel, 0, 1);
             inputCard.Controls.Add(inputLayout);
+            inputCard.Controls.Add(inputHeader);
+            inputCard.Controls.SetChildIndex(inputHeader, 0);
 
             // Target card
-            targetCard = new GroupBox { Text = "\uD83D\uDCC1 Target Project", Dock = DockStyle.Top, Height = 80 };
+            targetCard = new Panel
+            {
+                Dock = DockStyle.Top,
+                Height = 80,
+                Padding = new Padding(16),
+                BackColor = Color.FromArgb(45, 45, 45),
+                Margin = new Padding(0, 0, 0, 16)
+            };
+            var targetHeader = new Label
+            {
+                Text = "\uD83D\uDCC1 PROJECT FOLDER",
+                Dock = DockStyle.Top,
+                Font = new Font("Segoe UI", 12F, FontStyle.Bold),
+                ForeColor = Color.White,
+                Padding = new Padding(0, 0, 0, 8)
+            };
             var targetLayout = new TableLayoutPanel { Dock = DockStyle.Fill, ColumnCount = 2 };
             targetLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
             targetLayout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
             targetLayout.Controls.Add(folderBox, 0, 0);
             targetLayout.Controls.Add(browseFolderButton, 1, 0);
             targetCard.Controls.Add(targetLayout);
+            targetCard.Controls.Add(targetHeader);
+            targetCard.Controls.SetChildIndex(targetHeader, 0);
 
             // Action card
-            actionCard = new GroupBox { Text = "\u26A1 Apply Changes", Dock = DockStyle.Top, Height = 90 };
+            actionCard = new Panel
+            {
+                Dock = DockStyle.Top,
+                Height = 90,
+                Padding = new Padding(16),
+                BackColor = Color.FromArgb(45, 45, 45),
+                Margin = new Padding(0, 0, 0, 16)
+            };
+            var actionHeader = new Label
+            {
+                Text = "\u26A1 ACTIONS",
+                Dock = DockStyle.Top,
+                Font = new Font("Segoe UI", 12F, FontStyle.Bold),
+                ForeColor = Color.White,
+                Padding = new Padding(0, 0, 0, 8)
+            };
             var actionLayout = new FlowLayoutPanel { Dock = DockStyle.Fill, AutoSize = true };
             applyButton.Text = "\uD83D\uDE80 APPLY PATCH";
-            applyButton.Font = new Font("Segoe UI", 11, FontStyle.Bold);
+            applyButton.Font = new Font("Segoe UI", 11F, FontStyle.Bold);
             applyButton.Height = 40;
             previewButton.Text = "\uD83D\uDD0D Preview";
+            previewButton.AccentColor = Color.FromArgb(63, 63, 70);
             undoButton.Text = "\u21A9\uFE0F Undo";
+            undoButton.AccentColor = Color.FromArgb(63, 63, 70);
             actionLayout.Controls.Add(applyButton);
             actionLayout.Controls.Add(previewButton);
             actionLayout.Controls.Add(undoButton);
             actionLayout.Controls.Add(backupCheckBox);
             actionLayout.Controls.Add(dryRunCheckBox);
             actionCard.Controls.Add(actionLayout);
+            actionCard.Controls.Add(actionHeader);
+            actionCard.Controls.SetChildIndex(actionHeader, 0);
 
             // Results card
-            resultsCard = new GroupBox { Text = "\uD83D\uDCCB Results", Dock = DockStyle.Fill };
+            resultsCard = new Panel
+            {
+                Dock = DockStyle.Fill,
+                Padding = new Padding(16),
+                BackColor = Color.FromArgb(45, 45, 45)
+            };
+            var resultsHeader = new Label
+            {
+                Text = "\uD83D\uDCCB RESULTS",
+                Dock = DockStyle.Top,
+                Font = new Font("Segoe UI", 12F, FontStyle.Bold),
+                ForeColor = Color.White,
+                Padding = new Padding(0, 0, 0, 8)
+            };
             var resultLayout = new TableLayoutPanel { Dock = DockStyle.Fill, RowCount = 2 };
             resultLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
             resultLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
             resultLayout.Controls.Add(logBox, 0, 0);
             resultLayout.Controls.Add(progress, 0, 1);
             resultsCard.Controls.Add(resultLayout);
+            resultsCard.Controls.Add(resultsHeader);
+            resultsCard.Controls.SetChildIndex(resultsHeader, 0);
 
             mainPanel.Controls.Add(resultsCard);
             mainPanel.Controls.Add(actionCard);
@@ -108,6 +199,9 @@ namespace UniversalCodePatcher.Forms
             mainPanel.Controls.Add(inputCard);
 
             ClientSize = new Size(800, 600);
+            Font = new Font("Segoe UI", 10F);
+            ForeColor = Color.White;
+            BackColor = Color.FromArgb(30, 30, 30);
             Controls.Add(mainPanel);
             Controls.Add(menuStrip);
             MainMenuStrip = menuStrip;

--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -64,13 +64,20 @@ namespace UniversalCodePatcher.Forms
             {
                 var patch = parser.Parse(diffBox.Text);
                 if (patch.Files.Count > 0)
+                {
                     diffStatusLabel.Text = $"\u2714 Valid diff - {patch.Files.Count} files";
+                    diffStatusLabel.ForeColor = Color.FromArgb(22, 198, 12);
+                }
                 else
+                {
                     diffStatusLabel.Text = "\u274C Invalid diff";
+                    diffStatusLabel.ForeColor = Color.FromArgb(231, 72, 86);
+                }
             }
             catch
             {
                 diffStatusLabel.Text = "\u274C Invalid diff";
+                diffStatusLabel.ForeColor = Color.FromArgb(231, 72, 86);
             }
         }
 


### PR DESCRIPTION
## Summary
- modernize button accent color
- redesign `MainForm` layout using dark card panels
- highlight diff validation status with color feedback

## Testing
- `dotnet build UniversalCodePatcher.GUI/UniversalCodePatcher.GUI.csproj -v minimal`
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68429b1b6bc0832cb7e1bd1960356d34