### PR TITLE
Fix Source Code tab state

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -221,6 +221,11 @@ namespace UniversalCodePatcher.Forms
             previewTab.Controls.Add(previewBox);
             rulesTab.Controls.Add(rulesGrid);
             tabControl.TabPages.AddRange(new[] { sourceTab, previewTab, rulesTab });
+
+            // ensure source tab visible/enabled
+            sourceTab.Enabled = true;
+            sourceBox.Visible = true;
+
             horizontalSplit.Panel1.Controls.Add(tabControl);
 
             // Results group


### PR DESCRIPTION
## Summary
- remove obsolete `ui_report.py`
- ensure Source Code tab is enabled and visible at runtime

## Testing
- `dotnet test UniversalCodePatcher.sln --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68433fc5d3e8832c808e7a63cf3c8f02