### PR TITLE
Fix source editor and button layout

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/MainForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/MainForm.cs
@@ -214,13 +214,23 @@ namespace UniversalCodePatcher.Forms
             sourceTab = new TabPage("Source Code");
             previewTab = new TabPage("Preview Changes");
             rulesTab = new TabPage("Patch Rules");
-            sourceBox = new RichTextBox { Dock = DockStyle.Fill, ReadOnly = true, Font = new Font("Consolas", 9F) };
+            sourceBox = new RichTextBox
+            {
+                Dock = DockStyle.Fill,
+                ReadOnly = false,
+                Font = new Font("Consolas", 9F)
+            };
             previewBox = new RichTextBox { Dock = DockStyle.Fill, ReadOnly = true, Font = new Font("Consolas", 9F) };
             rulesGrid = new DataGridView { Dock = DockStyle.Fill };
             sourceTab.Controls.Add(sourceBox);
             previewTab.Controls.Add(previewBox);
             rulesTab.Controls.Add(rulesGrid);
             tabControl.TabPages.AddRange(new[] { sourceTab, previewTab, rulesTab });
+
+            // ensure source tab visible/enabled
+            sourceTab.Enabled = true;
+            sourceBox.Visible = true;
+
             horizontalSplit.Panel1.Controls.Add(tabControl);
 
             // Results group
@@ -236,7 +246,8 @@ namespace UniversalCodePatcher.Forms
             actionFlow = new FlowLayoutPanel
             {
                 Dock = DockStyle.Right,
-                FlowDirection = FlowDirection.RightToLeft
+                FlowDirection = FlowDirection.RightToLeft,
+                WrapContents = false
             };
             applyButton = new Button { Text = "Apply Patches", Size = new Size(90, 23), Margin = new Padding(3) };
             previewButton = new Button { Text = "Preview", Size = new Size(75, 23), Margin = new Padding(3) };


### PR DESCRIPTION
## Summary
- make the source text area editable
- prevent action buttons from wrapping so all buttons remain visible

## Testing
- `dotnet test UniversalCodePatcher.sln --verbosity minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433fc5d3e8832c808e7a63cf3c8f02