### PR TITLE
Add Avalonia dialog system

### DIFF
--- a/UniversalCodePatcher.Avalonia/App.axaml
+++ b/UniversalCodePatcher.Avalonia/App.axaml
@@ -1,10 +1,16 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
              x:Class="UniversalCodePatcher.Avalonia.App"
              RequestedThemeVariant="Default">
              <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
 
     <Application.Styles>
         <FluentTheme />
+        <Style Selector="local:BaseDialog Button">
+            <Setter Property="Width" Value="75" />
+            <Setter Property="Height" Value="23" />
+            <Setter Property="Margin" Value="4" />
+        </Style>
     </Application.Styles>
 </Application>

--- a/UniversalCodePatcher.Avalonia/Dialogs/BaseDialog.cs
+++ b/UniversalCodePatcher.Avalonia/Dialogs/BaseDialog.cs
@@ -1,0 +1,44 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+
+namespace UniversalCodePatcher.Avalonia;
+
+public abstract class BaseDialog : Window
+{
+    protected BaseDialog()
+    {
+        WindowStartupLocation = WindowStartupLocation.CenterOwner;
+        ShowInTaskbar = false;
+        CanResize = false;
+        SystemDecorations = SystemDecorations.BorderOnly;
+        Background = Brush.Parse("#F0F0F0");
+        FontFamily = new FontFamily("Segoe UI");
+        FontSize = 12;
+        KeyDown += OnKeyDown;
+    }
+
+    private void OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            DialogResult = false;
+            Close();
+        }
+    }
+
+    public bool? DialogResult { get; protected set; }
+
+    protected void SetOKResult()
+    {
+        DialogResult = true;
+        Close();
+    }
+
+    protected void SetCancelResult()
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/UniversalCodePatcher.Avalonia/Dialogs/ConfirmDialog.axaml
+++ b/UniversalCodePatcher.Avalonia/Dialogs/ConfirmDialog.axaml
@@ -1,0 +1,14 @@
+<local:BaseDialog xmlns="https://github.com/avaloniaui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
+                 x:Class="UniversalCodePatcher.Avalonia.ConfirmDialog"
+                 Width="350" Height="120" Title="Confirm">
+    <Grid RowDefinitions="*,Auto" ColumnDefinitions="Auto,*" Margin="16">
+        <TextBlock Text="?" FontSize="32" Foreground="Blue" />
+        <TextBlock x:Name="MessageText" Grid.Column="1" Margin="8,0,0,0" TextWrapping="Wrap"/>
+        <StackPanel Grid.Row="1" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8" Margin="0,16,0,0">
+            <Button Content="OK" Width="75" Click="OnOk" IsDefault="True"/>
+            <Button Content="Cancel" Width="75" Click="OnCancel" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Dialogs/ConfirmDialog.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Dialogs/ConfirmDialog.axaml.cs
@@ -1,0 +1,25 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using System.Threading.Tasks;
+
+namespace UniversalCodePatcher.Avalonia;
+
+public partial class ConfirmDialog : BaseDialog
+{
+    public ConfirmDialog(string message, string title)
+    {
+        InitializeComponent();
+        Title = title;
+        MessageText.Text = message;
+    }
+
+    public static async Task<bool?> ShowAsync(Window parent, string message, string title)
+    {
+        var dlg = new ConfirmDialog(message, title);
+        await dlg.ShowDialog(parent);
+        return dlg.DialogResult;
+    }
+
+    private void OnOk(object? sender, RoutedEventArgs e) => SetOKResult();
+    private void OnCancel(object? sender, RoutedEventArgs e) => SetCancelResult();
+}

--- a/UniversalCodePatcher.Avalonia/Dialogs/ErrorDialog.axaml
+++ b/UniversalCodePatcher.Avalonia/Dialogs/ErrorDialog.axaml
@@ -1,0 +1,12 @@
+<local:BaseDialog xmlns="https://github.com/avaloniaui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
+                 x:Class="UniversalCodePatcher.Avalonia.ErrorDialog"
+                 Width="400" Height="150" Title="Error">
+    <Grid RowDefinitions="*,Auto" ColumnDefinitions="Auto,*" Margin="16">
+        <TextBlock Text="❌" FontSize="32" Foreground="Red" />
+        <TextBlock x:Name="MessageText" Grid.Column="1" Margin="8,0,0,0" TextWrapping="Wrap"/>
+        <Button Grid.Row="1" Grid.ColumnSpan="2" Content="OK" Width="75" Height="23"
+                HorizontalAlignment="Right" Margin="0,16,0,0" Click="OnOk" IsDefault="True"/>
+    </Grid>
+</local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Dialogs/ErrorDialog.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Dialogs/ErrorDialog.axaml.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using System.Threading.Tasks;
+
+namespace UniversalCodePatcher.Avalonia;
+
+public partial class ErrorDialog : BaseDialog
+{
+    public ErrorDialog(string message)
+    {
+        InitializeComponent();
+        MessageText.Text = message;
+    }
+
+    public static async Task ShowAsync(Window parent, string message)
+    {
+        var dlg = new ErrorDialog(message);
+        await dlg.ShowDialog(parent);
+    }
+
+    private void OnOk(object? sender, RoutedEventArgs e) => SetOKResult();
+}

--- a/UniversalCodePatcher.Avalonia/Dialogs/InfoDialog.axaml
+++ b/UniversalCodePatcher.Avalonia/Dialogs/InfoDialog.axaml
@@ -1,0 +1,12 @@
+<local:BaseDialog xmlns="https://github.com/avaloniaui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
+                 x:Class="UniversalCodePatcher.Avalonia.InfoDialog"
+                 Width="300" Height="100" Title="Information">
+    <Grid RowDefinitions="*,Auto" ColumnDefinitions="Auto,*" Margin="16">
+        <TextBlock Text="ℹ" FontSize="32" Foreground="Blue" />
+        <TextBlock x:Name="MessageText" Grid.Column="1" Margin="8,0,0,0" TextWrapping="Wrap"/>
+        <Button Grid.Row="1" Grid.ColumnSpan="2" Content="OK" Width="75" Height="23"
+                HorizontalAlignment="Right" Margin="0,16,0,0" Click="OnOk" IsDefault="True"/>
+    </Grid>
+</local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Dialogs/InfoDialog.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Dialogs/InfoDialog.axaml.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using System.Threading.Tasks;
+
+namespace UniversalCodePatcher.Avalonia;
+
+public partial class InfoDialog : BaseDialog
+{
+    public InfoDialog(string message)
+    {
+        InitializeComponent();
+        MessageText.Text = message;
+    }
+
+    public static async Task ShowAsync(Window parent, string message)
+    {
+        var dlg = new InfoDialog(message);
+        await dlg.ShowDialog(parent);
+    }
+
+    private void OnOk(object? sender, RoutedEventArgs e) => SetOKResult();
+}

--- a/UniversalCodePatcher.Avalonia/MainWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/MainWindow.axaml.cs
@@ -40,16 +40,7 @@ public partial class MainWindow : Window
         _moduleManager = new ModuleManager(_services);
         _moduleManager.ModuleError += (_, e) =>
         {
-            var dlg = new Window
-            {
-                Title = "Module Error",
-                Content = new TextBlock { Text = e.Error, Margin = new Thickness(20) },
-                Width = 300,
-                Height = 150
-            };
- 
-            Dispatcher.UIThread.Post(() => dlg.ShowDialog(this));
- 
+            Dispatcher.UIThread.Post(async () => await ErrorDialog.ShowAsync(this, e.Error));
         };
 
         _moduleManager.LoadModule(typeof(JavaScriptModule));
@@ -79,7 +70,8 @@ public partial class MainWindow : Window
     private async void OnNewProject(object? sender, RoutedEventArgs e)
     {
         var dlg = new NewProjectWindow();
-        var result = await dlg.ShowDialog<bool?>(this);
+        await dlg.ShowDialog(this);
+        var result = dlg.DialogResult;
         if (result == true && !string.IsNullOrWhiteSpace(dlg.ProjectPath))
         {
             if (!Directory.Exists(dlg.ProjectPath))

--- a/UniversalCodePatcher.Avalonia/Windows/AboutWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/AboutWindow.axaml
@@ -1,9 +1,10 @@
-<Window xmlns="https://github.com/avaloniaui"
+<local:BaseDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
         x:Class="UniversalCodePatcher.Avalonia.AboutWindow"
         Width="300" Height="150" Title="About">
   <StackPanel Margin="20">
     <TextBlock x:Name="Label" HorizontalAlignment="Center"/>
     <Button Content="OK" HorizontalAlignment="Center" Width="80" Margin="0,20,0,0" IsDefault="True" Click="OnOk"/>
   </StackPanel>
-</Window>
+</local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/AboutWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/AboutWindow.axaml.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace UniversalCodePatcher.Avalonia;
 
-public partial class AboutWindow : Window
+public partial class AboutWindow : BaseDialog
 {
     public AboutWindow()
     {
@@ -13,5 +13,5 @@ public partial class AboutWindow : Window
         Label.Text = $"Universal Code Patcher\nVersion {version}";
     }
 
-    private void OnOk(object? sender, RoutedEventArgs e) => Close();
+    private void OnOk(object? sender, RoutedEventArgs e) => SetOKResult();
 }

--- a/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml
@@ -1,6 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
+<local:BaseDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
         x:Class="UniversalCodePatcher.Avalonia.BackupManagerWindow"
         Width="600" Height="400" Title="Backups">
   <ListBox x:Name="List" />
-</Window>
+</local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace UniversalCodePatcher.Avalonia;
 
-public partial class BackupManagerWindow : Window
+public partial class BackupManagerWindow : BaseDialog
 {
     public BackupManagerWindow(string directory)
     {

--- a/UniversalCodePatcher.Avalonia/Windows/FindWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/FindWindow.axaml
@@ -1,5 +1,6 @@
-<Window xmlns="https://github.com/avaloniaui"
+<local:BaseDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
         x:Class="UniversalCodePatcher.Avalonia.FindWindow"
         Width="600" Height="400" Title="Find in Files">
   <DockPanel>
@@ -9,4 +10,4 @@
     </StackPanel>
     <ListBox x:Name="ResultsList" DoubleTapped="OnDouble"/>
   </DockPanel>
-</Window>
+</local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/FindWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/FindWindow.axaml.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace UniversalCodePatcher.Avalonia;
 
-public partial class FindWindow : Window
+public partial class FindWindow : BaseDialog
 {
     private readonly string _root;
     public event Action<string>? FileSelected;

--- a/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml
@@ -1,6 +1,7 @@
-<Window xmlns="https://github.com/avaloniaui"
+<local:BaseDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
         x:Class="UniversalCodePatcher.Avalonia.ModuleManagerWindow"
         Width="400" Height="300" Title="Module Manager">
   <ListBox x:Name="ModuleList" SelectionMode="Multiple"/>
-</Window>
+</local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml.cs
@@ -4,7 +4,7 @@ using UniversalCodePatcher.Core;
 
 namespace UniversalCodePatcher.Avalonia;
 
-public partial class ModuleManagerWindow : Window
+public partial class ModuleManagerWindow : BaseDialog
 {
     public ModuleManagerWindow(ModuleManager manager)
     {

--- a/UniversalCodePatcher.Avalonia/Windows/NewProjectWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/NewProjectWindow.axaml
@@ -1,5 +1,6 @@
-<Window xmlns="https://github.com/avaloniaui"
+<local:BaseDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
         x:Class="UniversalCodePatcher.Avalonia.NewProjectWindow"
         Width="400" Height="150" Title="New Project">
   <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="Auto,*">
@@ -15,4 +16,4 @@
       <Button Content="Cancel" Width="70" Margin="5" IsCancel="True"/>
     </StackPanel>
   </Grid>
-</Window>
+</local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/NewProjectWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/NewProjectWindow.axaml.cs
@@ -5,7 +5,7 @@ using Avalonia.Platform.Storage;
 
 namespace UniversalCodePatcher.Avalonia;
 
-public partial class NewProjectWindow : Window
+public partial class NewProjectWindow : BaseDialog
 {
     public string ProjectName => NameBox.Text;
     public string ProjectPath => PathBox.Text;
@@ -24,5 +24,5 @@ public partial class NewProjectWindow : Window
             PathBox.Text = folder[0].Path.LocalPath;
     }
 
-    private void OnOk(object? sender, RoutedEventArgs e) => Close(true);
+    private void OnOk(object? sender, RoutedEventArgs e) => SetOKResult();
 }

--- a/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml
@@ -1,5 +1,6 @@
-<Window xmlns="https://github.com/avaloniaui"
+<local:BaseDialog xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
         x:Class="UniversalCodePatcher.Avalonia.SettingsWindow"
         Width="400" Height="300" Title="Settings">
   <TabControl>
@@ -7,4 +8,4 @@
     <TabItem Header="Modules"/>
     <TabItem Header="Appearance"/>
   </TabControl>
-</Window>
+</local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml.cs
@@ -2,7 +2,7 @@ using Avalonia.Controls;
 
 namespace UniversalCodePatcher.Avalonia;
 
-public partial class SettingsWindow : Window
+public partial class SettingsWindow : BaseDialog
 {
     public SettingsWindow()
     {


### PR DESCRIPTION
## Summary
- create reusable `BaseDialog` window class for modal dialogs
- implement `ErrorDialog`, `ConfirmDialog` and `InfoDialog`
- convert existing windows to inherit `BaseDialog`
- show module errors through `ErrorDialog`
- apply global dialog styles

## Testing
- `dotnet test UniversalCodePatcher.Tests/UniversalCodePatcher.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6843d21775b0832cb02742b35764927b