### PR TITLE
Fix NewProject dialog result

### DIFF
--- a/UniversalCodePatcher.Avalonia/MainWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/MainWindow.axaml.cs
@@ -70,8 +70,7 @@ public partial class MainWindow : Window
     private async void OnNewProject(object? sender, RoutedEventArgs e)
     {
         var dlg = new NewProjectWindow();
-        await dlg.ShowDialog(this);
-        var result = dlg.DialogResult;
+        var result = await dlg.ShowDialog<bool?>(this);
         if (result == true && !string.IsNullOrWhiteSpace(dlg.ProjectPath))
         {
             if (!Directory.Exists(dlg.ProjectPath))


### PR DESCRIPTION
## Summary
- handle new project dialog with ShowDialog return value

## Testing
- `dotnet build UniversalCodePatcher.Avalonia/UniversalCodePatcher.Avalonia.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6843e0b52be8832cb1eda7f0ae6ed9cc