### PR TITLE
Fix Avalonia dialog controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,11 @@ Intelligent multi-language code patcher with modular architecture.
 - .NET 6.0 or higher
 - Windows OS
 - Visual Studio 2022 (for development)
+
+## Avalonia Windows
+
+All Avalonia dialogs now include proper OK or Cancel buttons. The following windows were audited and fixed:
+- BackupManagerWindow
+- ModuleManagerWindow
+- SettingsWindow
+- FindWindow

--- a/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml
@@ -3,5 +3,9 @@
         xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
         x:Class="UniversalCodePatcher.Avalonia.BackupManagerWindow"
         Width="600" Height="400" Title="Backups">
-  <ListBox x:Name="List" />
+  <Grid RowDefinitions="*,Auto" Margin="10">
+    <ListBox x:Name="List" />
+    <Button Grid.Row="1" Content="Close" HorizontalAlignment="Right"
+            Width="80" Click="OnClose" IsCancel="True"/>
+  </Grid>
 </local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using System.IO;
 using System.Linq;
 
@@ -17,4 +18,6 @@ public partial class BackupManagerWindow : BaseDialog
             }
         }
     }
+
+    private void OnClose(object? sender, RoutedEventArgs e) => SetCancelResult();
 }

--- a/UniversalCodePatcher.Avalonia/Windows/FindWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/FindWindow.axaml
@@ -8,6 +8,8 @@
       <TextBox Width="400" x:Name="SearchBox"/>
       <Button Content="Search" Click="OnSearch" Margin="4,0,0,0"/>
     </StackPanel>
+    <Button Content="Close" DockPanel.Dock="Bottom" HorizontalAlignment="Right"
+            Margin="4" Width="80" Click="OnClose" IsCancel="True"/>
     <ListBox x:Name="ResultsList" DoubleTapped="OnDouble"/>
   </DockPanel>
 </local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/FindWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/FindWindow.axaml.cs
@@ -45,4 +45,6 @@ public partial class FindWindow : BaseDialog
             Close();
         }
     }
+
+    private void OnClose(object? sender, RoutedEventArgs e) => SetCancelResult();
 }

--- a/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml
@@ -3,5 +3,9 @@
         xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
         x:Class="UniversalCodePatcher.Avalonia.ModuleManagerWindow"
         Width="400" Height="300" Title="Module Manager">
-  <ListBox x:Name="ModuleList" SelectionMode="Multiple"/>
+  <Grid RowDefinitions="*,Auto" Margin="10">
+    <ListBox x:Name="ModuleList" SelectionMode="Multiple"/>
+    <Button Grid.Row="1" Content="Close" HorizontalAlignment="Right"
+            Width="80" Click="OnClose" IsCancel="True"/>
+  </Grid>
 </local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using System.Linq;
 using UniversalCodePatcher.Core;
 
@@ -12,4 +13,6 @@ public partial class ModuleManagerWindow : BaseDialog
         foreach (var m in manager.LoadedModules)
             ModuleList.Items.Add(m.Name);
     }
+
+    private void OnClose(object? sender, RoutedEventArgs e) => SetCancelResult();
 }

--- a/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml
@@ -3,9 +3,15 @@
         xmlns:local="clr-namespace:UniversalCodePatcher.Avalonia"
         x:Class="UniversalCodePatcher.Avalonia.SettingsWindow"
         Width="400" Height="300" Title="Settings">
-  <TabControl>
-    <TabItem Header="General"/>
-    <TabItem Header="Modules"/>
-    <TabItem Header="Appearance"/>
-  </TabControl>
+  <Grid RowDefinitions="*,Auto" Margin="10">
+    <TabControl>
+      <TabItem Header="General"/>
+      <TabItem Header="Modules"/>
+      <TabItem Header="Appearance"/>
+    </TabControl>
+    <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+      <Button Content="OK" Width="80" Click="OnOk" IsDefault="True"/>
+      <Button Content="Cancel" Width="80" Click="OnCancel" IsCancel="True"/>
+    </StackPanel>
+  </Grid>
 </local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace UniversalCodePatcher.Avalonia;
 
@@ -8,4 +9,7 @@ public partial class SettingsWindow : BaseDialog
     {
         InitializeComponent();
     }
+
+    private void OnOk(object? sender, RoutedEventArgs e) => SetOKResult();
+    private void OnCancel(object? sender, RoutedEventArgs e) => SetCancelResult();
 }


### PR DESCRIPTION
## Summary
- add Close buttons to module and backup windows
- add OK/Cancel buttons to settings window
- add Close button to find window
- document audited windows in README

## Testing
- `dotnet build UniversalCodePatcher.Avalonia/UniversalCodePatcher.Avalonia.csproj -v q`

------
https://chatgpt.com/codex/tasks/task_e_684454f04928832c869ce9ae0f6f4792