### PR TITLE
Integrate settings in Avalonia UI

### DIFF
--- a/UniversalCodePatcher.Avalonia/Models/AppSettings.cs
+++ b/UniversalCodePatcher.Avalonia/Models/AppSettings.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.IO;
+
+namespace UniversalCodePatcher.Avalonia.Models;
+
+public class AppSettings
+{
+    public bool ShowHiddenFiles { get; set; }
+    public string ThemeVariant { get; set; } = "Default";
+
+    public static AppSettings Load(string file)
+    {
+        try
+        {
+            if (File.Exists(file))
+            {
+                var json = File.ReadAllText(file);
+                var settings = JsonSerializer.Deserialize<AppSettings>(json);
+                if (settings != null)
+                    return settings;
+            }
+        }
+        catch { }
+        return new AppSettings();
+    }
+
+    public void Save(string file)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(this);
+            File.WriteAllText(file, json);
+        }
+        catch { }
+    }
+}

--- a/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml
@@ -5,9 +5,21 @@
         Width="400" Height="300" Title="Settings">
   <Grid RowDefinitions="*,Auto" Margin="10">
     <TabControl>
-      <TabItem Header="General"/>
+      <TabItem Header="General">
+        <StackPanel Margin="10" Spacing="8">
+          <CheckBox Content="Show hidden files" IsChecked="{Binding ShowHiddenFiles}"/>
+        </StackPanel>
+      </TabItem>
       <TabItem Header="Modules"/>
-      <TabItem Header="Appearance"/>
+      <TabItem Header="Appearance">
+        <StackPanel Margin="10" Spacing="8">
+          <ComboBox SelectedItem="{Binding ThemeVariant}" Width="150">
+            <ComboBoxItem Content="Default"/>
+            <ComboBoxItem Content="Light"/>
+            <ComboBoxItem Content="Dark"/>
+          </ComboBox>
+        </StackPanel>
+      </TabItem>
     </TabControl>
     <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
       <Button Content="OK" Width="80" Click="OnOk" IsDefault="True"/>

--- a/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml.cs
@@ -1,14 +1,19 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using System;
+using UniversalCodePatcher.Avalonia.Models;
 
 namespace UniversalCodePatcher.Avalonia;
 
 public partial class SettingsWindow : BaseDialog
 {
-    public SettingsWindow()
+    private readonly AppSettings _settings;
+
+    public SettingsWindow(AppSettings settings)
     {
+        _settings = settings;
         InitializeComponent();
+        DataContext = _settings;
     }
 
     private void OnOk(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- add `AppSettings` model for Avalonia settings persistence
- bind `SettingsWindow` to `AppSettings` with checkbox and theme selector
- load/save settings in `MainWindow` and update hidden file view

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445e076cac832cb45f0e8a4e87ce6a