### PR TITLE
Add missing dialog logic

### DIFF
--- a/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml
@@ -5,7 +5,10 @@
         Width="600" Height="400" Title="Backups">
   <Grid RowDefinitions="*,Auto" Margin="10">
     <ListBox x:Name="List" />
-    <Button Grid.Row="1" Content="Close" HorizontalAlignment="Right"
-            Width="80" Click="OnClose" IsCancel="True"/>
+    <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+      <Button Content="Restore" Width="80" Click="OnRestore"/>
+      <Button Content="Delete" Width="80" Click="OnDelete"/>
+      <Button Content="Close" Width="80" Click="OnClose" IsCancel="True"/>
+    </StackPanel>
   </Grid>
 </local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/BackupManagerWindow.axaml.cs
@@ -8,14 +8,23 @@ namespace UniversalCodePatcher.Avalonia;
 
 public partial class BackupManagerWindow : BaseDialog
 {
+    private readonly string _directory;
+
     public BackupManagerWindow(string directory)
     {
+        _directory = directory;
         InitializeComponent();
-        if (Directory.Exists(directory))
+        LoadBackups();
+    }
+
+    private void LoadBackups()
+    {
+        List.Items.Clear();
+        if (Directory.Exists(_directory))
         {
-            foreach (var file in Directory.GetFiles(directory, "*.bak_*", SearchOption.AllDirectories))
+            foreach (var file in Directory.GetFiles(_directory, "*.bak_*", SearchOption.AllDirectories))
             {
-                List.Items.Add($"{file} - {File.GetLastWriteTime(file)}");
+                List.Items.Add(file);
             }
         }
     }
@@ -24,5 +33,41 @@ public partial class BackupManagerWindow : BaseDialog
     {
         Console.WriteLine("Backup manager closed");
         SetCancelResult();
+    }
+
+    private void OnRestore(object? sender, RoutedEventArgs e)
+    {
+        if (List.SelectedItem is not string backupPath) return;
+        var originalPath = GetOriginalPath(backupPath);
+        try
+        {
+            File.Copy(backupPath, originalPath, true);
+            Console.WriteLine($"Restored {originalPath}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Restore failed: {ex.Message}");
+        }
+    }
+
+    private void OnDelete(object? sender, RoutedEventArgs e)
+    {
+        if (List.SelectedItem is not string backupPath) return;
+        try
+        {
+            File.Delete(backupPath);
+            List.Items.Remove(backupPath);
+            Console.WriteLine($"Deleted {backupPath}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Delete failed: {ex.Message}");
+        }
+    }
+
+    private static string GetOriginalPath(string backupPath)
+    {
+        var idx = backupPath.LastIndexOf(".bak_");
+        return idx > 0 ? backupPath.Substring(0, idx) : backupPath;
     }
 }

--- a/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml
+++ b/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml
@@ -4,8 +4,10 @@
         x:Class="UniversalCodePatcher.Avalonia.ModuleManagerWindow"
         Width="400" Height="300" Title="Module Manager">
   <Grid RowDefinitions="*,Auto" Margin="10">
-    <ListBox x:Name="ModuleList" SelectionMode="Multiple"/>
-    <Button Grid.Row="1" Content="Close" HorizontalAlignment="Right"
-            Width="80" Click="OnClose" IsCancel="True"/>
+    <ListBox x:Name="ModuleList" SelectionMode="Multiple" />
+    <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+      <Button Content="Unload" Width="80" Click="OnUnload"/>
+      <Button Content="Close" Width="80" Click="OnClose" IsCancel="True"/>
+    </StackPanel>
   </Grid>
 </local:BaseDialog>

--- a/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/ModuleManagerWindow.axaml.cs
@@ -3,21 +3,36 @@ using Avalonia.Interactivity;
 using System.Linq;
 using System;
 using UniversalCodePatcher.Core;
+using UniversalCodePatcher.Interfaces;
 
 namespace UniversalCodePatcher.Avalonia;
 
 public partial class ModuleManagerWindow : BaseDialog
 {
+    private readonly ModuleManager _manager;
+
     public ModuleManagerWindow(ModuleManager manager)
     {
+        _manager = manager;
         InitializeComponent();
-        foreach (var m in manager.LoadedModules)
-            ModuleList.Items.Add(m.Name);
+        ModuleList.DisplayMemberPath = "Name";
+        foreach (var m in _manager.LoadedModules)
+            ModuleList.Items.Add(m);
     }
 
     private void OnClose(object? sender, RoutedEventArgs e)
     {
         Console.WriteLine("Module manager closed");
         SetCancelResult();
+    }
+
+    private void OnUnload(object? sender, RoutedEventArgs e)
+    {
+        var modules = ModuleList.SelectedItems.Cast<IModule>().ToList();
+        foreach (var m in modules)
+        {
+            _manager.UnloadModule(m.ModuleId);
+            ModuleList.Items.Remove(m);
+        }
     }
 }

--- a/UniversalCodePatcher.Avalonia/Windows/NewProjectWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/NewProjectWindow.axaml.cs
@@ -25,8 +25,14 @@ public partial class NewProjectWindow : BaseDialog
             PathBox.Text = folder[0].Path.LocalPath;
     }
 
-    private void OnOk(object? sender, RoutedEventArgs e)
+    private async void OnOk(object? sender, RoutedEventArgs e)
     {
+        if (string.IsNullOrWhiteSpace(ProjectName) || string.IsNullOrWhiteSpace(ProjectPath))
+        {
+            await ErrorDialog.ShowAsync(this, "Name and location are required");
+            return;
+        }
+
         Console.WriteLine($"New project created: {ProjectName} at {ProjectPath}");
         SetOKResult();
     }

--- a/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml.cs
+++ b/UniversalCodePatcher.Avalonia/Windows/SettingsWindow.axaml.cs
@@ -8,6 +8,7 @@ namespace UniversalCodePatcher.Avalonia;
 public partial class SettingsWindow : BaseDialog
 {
     private readonly AppSettings _settings;
+    private readonly AppSettings _draft;
 
      // Parameterless constructor required for XAML designer
     public SettingsWindow() : this(new AppSettings())
@@ -17,13 +18,20 @@ public partial class SettingsWindow : BaseDialog
     public SettingsWindow(AppSettings settings)
     {
         _settings = settings;
+        _draft = new AppSettings
+        {
+            ShowHiddenFiles = settings.ShowHiddenFiles,
+            ThemeVariant = settings.ThemeVariant
+        };
         InitializeComponent();
-        DataContext = _settings;
+        DataContext = _draft;
     }
 
     private void OnOk(object? sender, RoutedEventArgs e)
     {
         Console.WriteLine("Settings saved");
+        _settings.ShowHiddenFiles = _draft.ShowHiddenFiles;
+        _settings.ThemeVariant = _draft.ThemeVariant;
         SetOKResult();
     }
 


### PR DESCRIPTION
## Summary
- flesh out BackupManagerWindow with restore/delete actions
- add module unloading to ModuleManagerWindow
- prevent cancelled settings from persisting
- validate new project fields before continuing

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68446b4a1cd0832c8fd57ba609702787