### PR TITLE
Add WinForms dialogs

### DIFF
--- a/UniversalCodePatcher.GUI/Forms/DiffViewerForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/DiffViewerForm.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using UniversalCodePatcher.Models;
+using UniversalCodePatcher.Controls;
+using UniversalCodePatcher.DiffEngine;
+
+namespace UniversalCodePatcher.Forms
+{
+    public class DiffViewerForm : Form
+    {
+        private readonly SplitContainer split = new() { Dock = DockStyle.Fill, Orientation = Orientation.Vertical };
+        private readonly RichTextBox originalBox = new() { Dock = DockStyle.Fill, Font = new Font("Consolas", 9), ReadOnly = true, WordWrap = false };
+        private readonly RichTextBox modifiedBox = new() { Dock = DockStyle.Fill, Font = new Font("Consolas", 9), ReadOnly = true, WordWrap = false };
+
+        public DiffViewerForm()
+        {
+            Text = "Diff Viewer";
+            Width = 800;
+            Height = 600;
+            StartPosition = FormStartPosition.CenterParent;
+
+            split.Panel1.Controls.Add(originalBox);
+            split.Panel2.Controls.Add(modifiedBox);
+            Controls.Add(split);
+        }
+
+        public void LoadDiff(string diffText)
+        {
+            originalBox.Clear();
+            modifiedBox.Clear();
+
+            var parser = new UnifiedDiffParser();
+            var patch = parser.Parse(diffText);
+            foreach (var file in patch.Files)
+            {
+                originalBox.AppendText($"--- {file.OriginalPath}\n");
+                modifiedBox.AppendText($"+++ {file.ModifiedPath}\n");
+                foreach (var hunk in file.Hunks)
+                {
+                    originalBox.AppendText($"@@ -{hunk.OriginalStart},{hunk.OriginalLength} +{hunk.ModifiedStart},{hunk.ModifiedLength} @@\n");
+                    modifiedBox.AppendText($"@@ -{hunk.OriginalStart},{hunk.OriginalLength} +{hunk.ModifiedStart},{hunk.ModifiedLength} @@\n");
+                    foreach (var line in hunk.Lines)
+                    {
+                        switch (line.Type)
+                        {
+                            case DiffLineType.Context:
+                                originalBox.AppendText(line.Content + "\n");
+                                modifiedBox.AppendText(line.Content + "\n");
+                                break;
+                            case DiffLineType.Removed:
+                                AppendColoredLine(originalBox, line.Content, Color.LightCoral);
+                                modifiedBox.AppendText("\n");
+                                break;
+                            case DiffLineType.Added:
+                                originalBox.AppendText("\n");
+                                AppendColoredLine(modifiedBox, line.Content, Color.LightGreen);
+                                break;
+                        }
+                    }
+                }
+            }
+            HighlightChanges();
+        }
+
+        private void AppendColoredLine(RichTextBox box, string text, Color color)
+        {
+            int start = box.TextLength;
+            box.AppendText(text + "\n");
+            box.Select(start, text.Length);
+            box.SelectionBackColor = color;
+            box.SelectionLength = 0;
+        }
+
+        public void HighlightChanges()
+        {
+            // selection done during append, ensure caret at start
+            originalBox.SelectionStart = 0;
+            modifiedBox.SelectionStart = 0;
+        }
+    }
+}

--- a/UniversalCodePatcher.GUI/Forms/ProgressForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/ProgressForm.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using UniversalCodePatcher.Models;
+using UniversalCodePatcher.Controls;
+
+namespace UniversalCodePatcher.Forms
+{
+    public class ProgressForm : Form
+    {
+        private readonly ProgressBar progressBar = new() { Dock = DockStyle.Top };
+        private readonly Label infoLabel = new() { Dock = DockStyle.Top, Height = 20 };
+        private readonly ListBox logBox = new() { Dock = DockStyle.Fill };
+        private readonly Button cancelButton = new() { Text = "Cancel", Dock = DockStyle.Bottom };
+
+        public event Action? CancellationRequested;
+
+        public ProgressForm()
+        {
+            Text = "Progress";
+            Width = 400;
+            Height = 300;
+            StartPosition = FormStartPosition.CenterParent;
+
+            Controls.Add(logBox);
+            Controls.Add(cancelButton);
+            Controls.Add(infoLabel);
+            Controls.Add(progressBar);
+
+            cancelButton.Click += (_, __) => CancellationRequested?.Invoke();
+        }
+
+        public void UpdateProgress(int value, string message)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(new Action(() => UpdateProgress(value, message)));
+                return;
+            }
+            progressBar.Value = Math.Max(progressBar.Minimum, Math.Min(value, progressBar.Maximum));
+            infoLabel.Text = message;
+        }
+
+        public void AddLog(string message)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(new Action<string>(AddLog), message);
+                return;
+            }
+            logBox.Items.Add($"[{DateTime.Now:HH:mm:ss}] {message}");
+            logBox.TopIndex = logBox.Items.Count - 1;
+        }
+    }
+}

--- a/UniversalCodePatcher.GUI/Forms/RuleEditorForm.cs
+++ b/UniversalCodePatcher.GUI/Forms/RuleEditorForm.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using UniversalCodePatcher.Models;
+using UniversalCodePatcher.Controls;
+
+namespace UniversalCodePatcher.Forms
+{
+    public class RuleEditorForm : Form
+    {
+        private readonly PatchRule _rule;
+        private readonly TextBox nameBox = new();
+        private readonly TextBox descriptionBox = new();
+        private readonly ComboBox patchTypeCombo = new() { DropDownStyle = ComboBoxStyle.DropDownList };
+        private readonly TextBox patternBox = new();
+        private readonly TextBox newContentBox = new() { Multiline = true, ScrollBars = ScrollBars.Both, Height = 120 };
+        private readonly Button okButton = new() { Text = "OK", Width = 80 };
+        private readonly Button cancelButton = new() { Text = "Cancel", Width = 80 };
+
+        public PatchRule Rule => _rule;
+
+        public RuleEditorForm(PatchRule rule = null)
+        {
+            _rule = rule ?? new PatchRule();
+            InitializeComponent();
+            LoadRuleToControls();
+        }
+
+        private void InitializeComponent()
+        {
+            Text = "Rule Editor";
+            Width = 500;
+            Height = 400;
+            StartPosition = FormStartPosition.CenterParent;
+
+            patchTypeCombo.Items.AddRange(Enum.GetValues(typeof(PatchType)).Cast<object>().ToArray());
+
+            var layout = new TableLayoutPanel { Dock = DockStyle.Fill, ColumnCount = 2, RowCount = 5, Padding = new Padding(6) };
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 100));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+
+            layout.Controls.Add(new Label { Text = "Name", TextAlign = ContentAlignment.MiddleLeft }, 0, 0);
+            layout.Controls.Add(nameBox, 1, 0);
+
+            layout.Controls.Add(new Label { Text = "Description", TextAlign = ContentAlignment.MiddleLeft }, 0, 1);
+            layout.Controls.Add(descriptionBox, 1, 1);
+
+            layout.Controls.Add(new Label { Text = "Patch Type", TextAlign = ContentAlignment.MiddleLeft }, 0, 2);
+            layout.Controls.Add(patchTypeCombo, 1, 2);
+
+            layout.Controls.Add(new Label { Text = "Pattern", TextAlign = ContentAlignment.MiddleLeft }, 0, 3);
+            layout.Controls.Add(patternBox, 1, 3);
+
+            layout.Controls.Add(new Label { Text = "New Content", TextAlign = ContentAlignment.MiddleLeft }, 0, 4);
+            layout.Controls.Add(newContentBox, 1, 4);
+
+            var buttons = new FlowLayoutPanel { FlowDirection = FlowDirection.RightToLeft, Dock = DockStyle.Bottom, Padding = new Padding(8), Height = 40 };
+            buttons.Controls.Add(cancelButton);
+            buttons.Controls.Add(okButton);
+
+            Controls.Add(layout);
+            Controls.Add(buttons);
+
+            AcceptButton = okButton;
+            CancelButton = cancelButton;
+
+            okButton.Click += OnOk;
+            cancelButton.Click += (_, __) => Close();
+        }
+
+        private void OnOk(object? sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(nameBox.Text))
+            {
+                MessageBox.Show("Name is required");
+                return;
+            }
+            SaveControlsToRule();
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        public void LoadRuleToControls()
+        {
+            nameBox.Text = _rule.Name;
+            descriptionBox.Text = _rule.Description;
+            patchTypeCombo.SelectedItem = _rule.PatchType;
+            patternBox.Text = _rule.TargetPattern;
+            newContentBox.Text = _rule.NewContent;
+        }
+
+        public void SaveControlsToRule()
+        {
+            _rule.Name = nameBox.Text;
+            _rule.Description = descriptionBox.Text;
+            if (patchTypeCombo.SelectedItem is PatchType pt)
+                _rule.PatchType = pt;
+            _rule.TargetPattern = patternBox.Text;
+            _rule.NewContent = newContentBox.Text;
+            _rule.UpdatedAt = DateTime.Now;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add RuleEditorForm with patch-type selection, load/save helpers
- add DiffViewerForm to display and color diff output
- add ProgressForm for reporting progress and logs

## Testing
- `bash dotnet-install.sh --version 8.0.100 --install-dir $HOME/dotnet`
- `dotnet build UniversalCodePatcher.sln -c Release`
- `dotnet run --project UniversalCodePatcher.GUI --no-build` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684706521ac8832ca9f8f035bb1ef272